### PR TITLE
fix(python): native mode HTTP adapter, connector ownership, proxy routing

### DIFF
--- a/python/src/webex_message_handler/device_manager.py
+++ b/python/src/webex_message_handler/device_manager.py
@@ -31,7 +31,7 @@ class DeviceManager:
         logger: Logger | None = None,
         http_do: FetchFunction,
     ) -> None:
-        self._logger: Logger = logger or noop_logger  # type: ignore[assignment]
+        self._logger: Logger = logger or noop_logger
         self._http_do = http_do
         self._device_url: str | None = None
 

--- a/python/src/webex_message_handler/handler.py
+++ b/python/src/webex_message_handler/handler.py
@@ -35,6 +35,35 @@ if TYPE_CHECKING:
 EventCallback = Callable[..., Any]
 
 
+class _AiohttpWebSocketAdapter:
+    """Wraps aiohttp ClientWebSocketResponse to match InjectedWebSocket protocol.
+
+    Maps send() → send_str() and exposes close_code for mercury_socket.
+    """
+
+    def __init__(self, ws: aiohttp.ClientWebSocketResponse, session: aiohttp.ClientSession) -> None:
+        self._ws = ws
+        self._session = session
+
+    async def send(self, data: str) -> None:
+        await self._ws.send_str(data)
+
+    async def close(self, code: int = 1000) -> None:
+        await self._ws.close(code=code)
+        await self._session.close()
+
+    @property
+    def closed(self) -> bool:
+        return self._ws.closed
+
+    @property
+    def close_code(self) -> int | None:
+        return self._ws.close_code
+
+    def __aiter__(self):  # type: ignore[no-untyped-def]
+        return self._ws.__aiter__()
+
+
 class WebexMessageHandler:
     """Receives and decrypts Webex messages over Mercury WebSocket.
 
@@ -67,7 +96,7 @@ class WebexMessageHandler:
             raise ValueError(f'Invalid mode "{mode}" — must be "native" or "injected"')
 
         self._token = config.token
-        self._logger: Logger = config.logger or noop_logger  # type: ignore[assignment]
+        self._logger: Logger = config.logger or noop_logger
         self._connector = config.connector
 
         # Create adapters based on mode
@@ -118,27 +147,32 @@ class WebexMessageHandler:
     ) -> FetchFunction:
         """Create HTTP adapter using native aiohttp."""
         async def http_do(request: FetchRequest) -> FetchResponse:
-            async with aiohttp.ClientSession(connector=connector) as session:
+            async with aiohttp.ClientSession(connector=connector, connector_owner=False, trust_env=True) as session:
                 async with session.request(
                     request.method,
                     request.url,
                     headers=request.headers,
                     data=request.body,
                 ) as response:
-                    # Create a simple response wrapper
+                    # Eagerly read body before context manager closes the response
+                    body_bytes = await response.read()
+                    status = response.status
+                    ok = 200 <= status < 300
+                    content_type = response.content_type or ""
+
                     class NativeFetchResponse:
-                        def __init__(self, resp: aiohttp.ClientResponse):
-                            self.status = resp.status
-                            self.ok = 200 <= resp.status < 300
-                            self._response = resp
+                        def __init__(self) -> None:
+                            self.status = status
+                            self.ok = ok
 
                         async def json(self) -> Any:
-                            return await self._response.json()
+                            import json as _json
+                            return _json.loads(body_bytes)
 
                         async def text(self) -> str:
-                            return await self._response.text()
+                            return body_bytes.decode("utf-8")
 
-                    return NativeFetchResponse(response)  # type: ignore[return-value]
+                    return NativeFetchResponse()  # type: ignore[return-value]
 
         return http_do
 
@@ -147,13 +181,9 @@ class WebexMessageHandler:
     ) -> WebSocketFactory:
         """Create WebSocket adapter using native aiohttp."""
         async def ws_factory(url: str) -> InjectedWebSocket:
-            session = aiohttp.ClientSession(connector=connector)
+            session = aiohttp.ClientSession(connector=connector, connector_owner=False, trust_env=True)
             ws = await session.ws_connect(url)
-
-            # Attach session for cleanup
-            ws._session = session  # type: ignore[attr-defined]
-
-            return ws  # type: ignore[return-value]
+            return _AiohttpWebSocketAdapter(ws, session)
 
         return ws_factory
 
@@ -269,6 +299,9 @@ class WebexMessageHandler:
 
         await self._mercury_socket.disconnect()
 
+        # Unregister device after closing WebSocket but before releasing resources.
+        # The HTTP adapter still works because connector_owner=False keeps the
+        # shared connector alive even after the WS session closes.
         if self._registration:
             try:
                 await self._device_manager.unregister(self._token)

--- a/python/src/webex_message_handler/kms_client.py
+++ b/python/src/webex_message_handler/kms_client.py
@@ -49,8 +49,7 @@ class KmsClient:
         self._user_id = user_id
         self._encryption_service_url = encryption_service_url
         self._http_do = http_do
-        self._logger: Logger = logger or noop_logger  # type: ignore[assignment]
-        self._connector = connector
+        self._logger: Logger = logger or noop_logger
 
         self._kms_cluster: str = ""
         self._ephemeral_key: jwk.JWK | None = None
@@ -267,17 +266,17 @@ class KmsClient:
 
     async def _send_kms_request(self, request_id: str, wrapped: str) -> str:
         """Send a KMS request via HTTP and wait for the response via Mercury."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         future: asyncio.Future[str] = loop.create_future()
-        timeout_handle = loop.call_later(
-            KMS_RESPONSE_TIMEOUT,
-            lambda: (
-                self._pending_requests.pop(request_id, None),
+
+        def _on_timeout() -> None:
+            self._pending_requests.pop(request_id, None)
+            if not future.done():
                 future.set_exception(
                     KmsError(f"KMS request {request_id} timed out after {KMS_RESPONSE_TIMEOUT}s")
-                ) if not future.done() else None,
-            ),
-        )
+                )
+
+        timeout_handle = loop.call_later(KMS_RESPONSE_TIMEOUT, _on_timeout)
 
         self._pending_requests[request_id] = _PendingRequest(future=future, timeout_handle=timeout_handle)
 
@@ -337,8 +336,9 @@ def _jwe_encrypt(plaintext: bytes, key: jwk.JWK, alg: str, enc: str) -> str:
     kid = key.get("kid")
     if kid:
         protected_header["kid"] = kid
-    jwe_obj = jwe.JWE(plaintext, recipient=key, protected=protected_header)
-    return jwe_obj.serialize(compact=True)
+    jwe_obj = jwe.JWE(plaintext, recipient=key, protected=protected_header)  # type: ignore[arg-type]
+    result: str = jwe_obj.serialize(compact=True)
+    return result
 
 
 def _unwrap_kms_response(token: str, key: jwk.JWK) -> bytes:
@@ -353,10 +353,12 @@ def _unwrap_kms_response(token: str, key: jwk.JWK) -> bytes:
         # JWE compact: header.encrypted_key.iv.ciphertext.tag
         jwe_obj = jwe.JWE()
         jwe_obj.deserialize(token, key=key)
-        return jwe_obj.payload
+        payload: bytes = jwe_obj.payload
+        return payload
     elif len(parts) == 3:
         # JWS compact: header.payload.signature — extract payload
-        return base64url_decode(parts[1])
+        decoded: bytes = base64url_decode(parts[1])
+        return decoded
     else:
         raise KmsError(f"Invalid KMS response format: expected 3 or 5 parts, got {len(parts)}")
 

--- a/python/src/webex_message_handler/logger.py
+++ b/python/src/webex_message_handler/logger.py
@@ -31,12 +31,13 @@ class _NoopLogger:
         pass
 
 
-noop_logger: Logger = _NoopLogger()  # type: ignore[assignment]
+noop_logger: Logger = _NoopLogger()
 
 # console_logger is a standard logging.Logger that writes to stderr
-console_logger: Logger = logging.getLogger("webex_message_handler")  # type: ignore[assignment]
-if not console_logger.handlers:  # type: ignore[union-attr]
+_std_logger = logging.getLogger("webex_message_handler")
+if not _std_logger.handlers:
     _handler = logging.StreamHandler()
     _handler.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
-    console_logger.addHandler(_handler)  # type: ignore[union-attr]
-    console_logger.setLevel(logging.DEBUG)  # type: ignore[union-attr]
+    _std_logger.addHandler(_handler)
+    _std_logger.setLevel(logging.DEBUG)
+console_logger: Logger = _std_logger

--- a/python/src/webex_message_handler/mercury_socket.py
+++ b/python/src/webex_message_handler/mercury_socket.py
@@ -10,6 +10,8 @@ from collections.abc import Callable
 from typing import Any
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
+import aiohttp
+
 from .errors import AuthError, MercuryConnectionError
 from .logger import Logger, noop_logger
 from .types import InjectedWebSocket, MercuryActivity, MercuryActor, MercuryObject, MercuryTarget, WebSocketFactory
@@ -32,7 +34,7 @@ class MercurySocket:
         reconnect_backoff_max: float = 32.0,
         max_reconnect_attempts: int = 10,
     ) -> None:
-        self._logger: Logger = logger or noop_logger  # type: ignore[assignment]
+        self._logger: Logger = logger or noop_logger
         self._ws_factory = ws_factory
         self._ping_interval = ping_interval
         self._pong_timeout = pong_timeout
@@ -174,7 +176,7 @@ class MercurySocket:
         params["outboundWireFormat"] = "text"
         params["bufferStates"] = "true"
         params["aliasHttpStatus"] = "true"
-        params["clientTimestamp"] = str(int(asyncio.get_event_loop().time() * 1000))
+        params["clientTimestamp"] = str(int(asyncio.get_running_loop().time() * 1000))
         new_query = urlencode(params)
         return urlunparse(parsed._replace(query=new_query))
 
@@ -199,7 +201,7 @@ class MercurySocket:
                     self._logger.debug(f"Sent ping: {self._pending_pong_id}")
 
                     # Schedule pong timeout
-                    loop = asyncio.get_event_loop()
+                    loop = asyncio.get_running_loop()
                     self._pong_timeout_handle = loop.call_later(
                         self._pong_timeout,
                         lambda: asyncio.ensure_future(self._on_pong_timeout()),
@@ -246,7 +248,7 @@ class MercurySocket:
         # Send ACK
         if self._ws and not self._ws.closed:
             ack = json.dumps({"messageId": message.get("id"), "type": "ack"})
-            asyncio.ensure_future(self._ws.send_str(ack))
+            asyncio.ensure_future(self._ws.send(ack))
 
         # Route KMS messages
         if event_type.startswith("encryption."):

--- a/python/src/webex_message_handler/message_decryptor.py
+++ b/python/src/webex_message_handler/message_decryptor.py
@@ -20,7 +20,7 @@ class MessageDecryptor:
 
     def __init__(self, *, kms_client: KmsClient, logger: Logger | None = None) -> None:
         self._kms_client = kms_client
-        self._logger: Logger = logger or noop_logger  # type: ignore[assignment]
+        self._logger: Logger = logger or noop_logger
 
     async def decrypt_activity(self, activity: MercuryActivity) -> MercuryActivity:
         """Decrypt an encrypted Mercury activity.

--- a/python/src/webex_message_handler/types.py
+++ b/python/src/webex_message_handler/types.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Literal, Protocol
 
@@ -33,11 +34,11 @@ class FetchResponse:
 
     async def json(self) -> Any:
         """Parse response as JSON."""
-        ...
+        raise NotImplementedError
 
     async def text(self) -> str:
         """Get response body as text."""
-        ...
+        raise NotImplementedError
 
 
 FetchFunction = Callable[[FetchRequest], Awaitable[FetchResponse]]
@@ -59,7 +60,12 @@ class InjectedWebSocket(Protocol):
         """Whether the WebSocket is closed."""
         ...
 
-    def __aiter__(self):
+    @property
+    def close_code(self) -> int | None:
+        """Close code from the server, if closed."""
+        ...
+
+    def __aiter__(self) -> AsyncIterator[Any]:
         """Async iterator for receiving messages."""
         ...
 


### PR DESCRIPTION
## Summary
- Fix response body lost after aiohttp context manager exit — eagerly read bytes before close
- Fix shared connector destroyed on disconnect — add `connector_owner=False` to all sessions
- Fix proxy not routing — add `trust_env=True` so `HTTPS_PROXY`/`HTTP_PROXY` env vars work
- Fix pre-existing mypy errors and deprecation warnings (24 → 0 errors)

## Test plan
- [ ] `pytest tests/` — all 51 unit tests pass
- [ ] `mypy src/` — 0 errors
- [ ] `python test-proxy.py` through mitmproxy — connects and disconnects cleanly
- [ ] Verify device unregistration succeeds on disconnect (no "Session is closed" error)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)