### PR TITLE
fix(rust): resolve all clippy warnings and correct proxy documentation

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -83,7 +83,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-Note: WebSocket proxy support in Rust uses environment variables (`HTTPS_PROXY`, `HTTP_PROXY`) which `tokio-tungstenite` respects automatically.
+Note: The `reqwest::Client` proxy applies to HTTP traffic (device registration, KMS). WebSocket (Mercury) connections via `tokio-tungstenite` connect directly and do not route through the proxy. For full WebSocket proxy support, use injected mode with a custom `WebSocketFactory`.
 
 ## Configuration
 

--- a/rust/examples/basic_bot.rs
+++ b/rust/examples/basic_bot.rs
@@ -5,7 +5,6 @@
 
 use std::env;
 use tokio::signal;
-use tracing_subscriber;
 use webex_message_handler::{Config, HandlerEvent, WebexMessageHandler};
 
 #[tokio::main]

--- a/rust/src/handler.rs
+++ b/rust/src/handler.rs
@@ -27,7 +27,7 @@ type HttpDoFn = Arc<
 #[derive(Debug, Clone)]
 pub enum HandlerEvent {
     /// A new message was received and decrypted.
-    MessageCreated(DecryptedMessage),
+    MessageCreated(Box<DecryptedMessage>),
     /// A message was deleted.
     MessageDeleted(DeletedMessage),
     /// Successfully connected (or reconnected).
@@ -139,7 +139,7 @@ impl WebexMessageHandler {
         // Create adapters based on mode
         let (http_do, ws_factory) = match config.mode {
             NetworkMode::Native => {
-                let client = config.client.clone().unwrap_or_else(|| reqwest::Client::new());
+                let client = config.client.clone().unwrap_or_default();
                 let http_adapter = create_native_http_adapter(client.clone());
                 (http_adapter, None)
             }
@@ -444,7 +444,7 @@ impl WebexMessageHandler {
                         }
                     }
 
-                    let _ = event_tx.send(HandlerEvent::MessageCreated(msg));
+                    let _ = event_tx.send(HandlerEvent::MessageCreated(Box::new(msg)));
                 }
                 Err(e) => {
                     error!("Error decrypting activity: {e}");

--- a/rust/src/jwe.rs
+++ b/rust/src/jwe.rs
@@ -66,7 +66,7 @@ pub fn encrypt_rsa_oaep_a256gcm(
         "{}.{}.{}.{}.{}",
         header_b64,
         URL_SAFE_NO_PAD.encode(&encrypted_key),
-        URL_SAFE_NO_PAD.encode(&iv),
+        URL_SAFE_NO_PAD.encode(iv),
         URL_SAFE_NO_PAD.encode(ciphertext),
         URL_SAFE_NO_PAD.encode(tag),
     ))
@@ -105,7 +105,7 @@ pub fn encrypt_dir_a256gcm(
         "{}.{}.{}.{}.{}",
         header_b64,
         "",  // empty encrypted key for dir
-        URL_SAFE_NO_PAD.encode(&iv),
+        URL_SAFE_NO_PAD.encode(iv),
         URL_SAFE_NO_PAD.encode(ciphertext),
         URL_SAFE_NO_PAD.encode(tag),
     ))
@@ -149,7 +149,7 @@ pub fn encrypt_a256kw_a256gcm(
         "{}.{}.{}.{}.{}",
         header_b64,
         URL_SAFE_NO_PAD.encode(&wrapped_key),
-        URL_SAFE_NO_PAD.encode(&iv),
+        URL_SAFE_NO_PAD.encode(iv),
         URL_SAFE_NO_PAD.encode(ciphertext),
         URL_SAFE_NO_PAD.encode(tag),
     ))
@@ -427,7 +427,7 @@ fn concat_kdf(
     use sha2::{Digest, Sha256};
 
     let key_data_len = (key_data_len_bits / 8) as usize;
-    let reps = (key_data_len + 31) / 32; // ceil(keyDataLen / hashLen)
+    let reps = key_data_len.div_ceil(32); // ceil(keyDataLen / hashLen)
 
     let mut derived = Vec::with_capacity(key_data_len);
 

--- a/rust/src/kms_client.rs
+++ b/rust/src/kms_client.rs
@@ -190,8 +190,8 @@ impl KmsClient {
         let public_jwk_map = serde_json::json!({
             "kty": "EC",
             "crv": "P-256",
-            "x": URL_SAFE_NO_PAD.encode(&*x_bytes),
-            "y": URL_SAFE_NO_PAD.encode(&*y_bytes),
+            "x": URL_SAFE_NO_PAD.encode(&x_bytes[..]),
+            "y": URL_SAFE_NO_PAD.encode(&y_bytes[..]),
         });
 
         // Step 3: Build ECDH request body

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -45,7 +45,7 @@ pub mod types;
 pub use errors::WebexError;
 pub use handler::{HandlerEvent, WebexMessageHandler};
 pub use types::{
-    Config, ConnectionStatus, DecryptedMessage, DeletedMessage, DeviceRegistration, FetchFn,
-    FetchRequest, FetchResponse, HandlerStatus, InjectedWebSocket, MercuryActivity, MercuryActor,
-    MercuryObject, MercuryTarget, NetworkMode, WebSocketFactory,
+    BoxError, Config, ConnectionStatus, DecryptedMessage, DeletedMessage, DeviceRegistration,
+    FetchFn, FetchRequest, FetchResponse, HandlerStatus, InjectedWebSocket, MercuryActivity,
+    MercuryActor, MercuryObject, MercuryTarget, NetworkMode, WebSocketFactory,
 };

--- a/rust/src/mercury_socket.rs
+++ b/rust/src/mercury_socket.rs
@@ -1,17 +1,20 @@
 //! Mercury WebSocket connection with auth, heartbeat, and reconnection.
 
 use crate::errors::WebexError;
-use crate::types::MercuryActivity;
+use crate::types::{MercuryActivity, WebSocketFactory};
 use futures_util::{SinkExt, StreamExt};
 use serde_json::Value;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{mpsc, Mutex, Notify};
 use tokio::time;
-use tokio_tungstenite::{connect_async, tungstenite::Message};
+use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
 use tracing::{debug, error, info};
 use url::Url;
 use uuid::Uuid;
+
+/// Type alias for the write half of a WebSocket stream.
+type WsSink = futures_util::stream::SplitSink<WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>, Message>;
 
 /// Events emitted by the Mercury socket.
 #[derive(Debug, Clone)]
@@ -19,7 +22,7 @@ pub enum MercuryEvent {
     Connected,
     Disconnected(String),
     Reconnecting(u32),
-    Activity(MercuryActivity),
+    Activity(Box<MercuryActivity>),
     KmsResponse(Value),
     Error(String),
 }
@@ -27,7 +30,7 @@ pub enum MercuryEvent {
 /// Mercury WebSocket connection manager.
 pub struct MercurySocket {
     #[allow(dead_code)]
-    ws_factory: Option<Arc<dyn Fn(String) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Box<dyn crate::types::InjectedWebSocket>, Box<dyn std::error::Error + Send + Sync>>> + Send>> + Send + Sync>>,
+    ws_factory: Option<WebSocketFactory>,
     ping_interval: Duration,
     pong_timeout: Duration,
     reconnect_backoff_max: Duration,
@@ -46,7 +49,7 @@ pub struct MercurySocket {
 
 impl MercurySocket {
     pub fn new(
-        _ws_factory: Option<Arc<dyn Fn(String) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Box<dyn crate::types::InjectedWebSocket>, Box<dyn std::error::Error + Send + Sync>>> + Send>> + Send + Sync>>,
+        _ws_factory: Option<WebSocketFactory>,
         ping_interval: Duration,
         pong_timeout: Duration,
         reconnect_backoff_max: Duration,
@@ -106,7 +109,7 @@ impl MercurySocket {
             "data": { "token": format!("Bearer {}", token) }
         });
         write
-            .send(Message::Text(auth_msg.to_string().into()))
+            .send(Message::Text(auth_msg.to_string()))
             .await
             .map_err(|e| WebexError::mercury_connection(format!("Failed to send auth: {e}"), None))?;
 
@@ -176,7 +179,7 @@ impl MercurySocket {
                             "type": "ping"
                         });
                         let mut w = ping_write.lock().await;
-                        if w.send(Message::Text(ping_msg.to_string().into())).await.is_err() {
+                        if w.send(Message::Text(ping_msg.to_string())).await.is_err() {
                             break;
                         }
                         debug!("Sent ping: {pong_id}");
@@ -231,7 +234,7 @@ impl MercurySocket {
             }
 
             // Connection ended — handle reconnection if needed
-            if *should_reconnect.lock().await && *connected.lock().await == false {
+            if *should_reconnect.lock().await && !*connected.lock().await {
                 // Reconnect logic handled in handle_close_static
             }
         });
@@ -269,7 +272,7 @@ impl MercurySocket {
     async fn handle_message_static(
         message: &Value,
         event_tx: &mpsc::UnboundedSender<MercuryEvent>,
-        write: &Arc<Mutex<futures_util::stream::SplitSink<tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>, Message>>>,
+        write: &Arc<Mutex<WsSink>>,
     ) {
         let msg_type = message.get("type").and_then(|t| t.as_str()).unwrap_or("");
 
@@ -291,7 +294,7 @@ impl MercurySocket {
                         if let Some(msg_id) = message.get("id").and_then(|i| i.as_str()) {
                             let ack = serde_json::json!({"messageId": msg_id, "type": "ack"});
                             let mut w = write.lock().await;
-                            let _ = w.send(Message::Text(ack.to_string().into())).await;
+                            let _ = w.send(Message::Text(ack.to_string())).await;
                         }
 
                         if event_type.starts_with("encryption.") {
@@ -302,7 +305,7 @@ impl MercurySocket {
                                 match serde_json::from_value::<MercuryActivity>(activity_raw.clone()) {
                                     Ok(activity) => {
                                         debug!("Emitting activity: {}", activity.id);
-                                        let _ = event_tx.send(MercuryEvent::Activity(activity));
+                                        let _ = event_tx.send(MercuryEvent::Activity(Box::new(activity)));
                                     }
                                     Err(e) => {
                                         error!("Failed to parse activity: {e}");

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -7,18 +7,13 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 /// Networking mode for the handler.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum NetworkMode {
     /// Use built-in HTTP and WebSocket libraries (default).
+    #[default]
     Native,
     /// Use provided fetch and WebSocket factory functions.
     Injected,
-}
-
-impl Default for NetworkMode {
-    fn default() -> Self {
-        Self::Native
-    }
 }
 
 /// HTTP request for injected fetch function.
@@ -37,23 +32,26 @@ pub struct FetchResponse {
     pub body: Vec<u8>,
 }
 
+/// Boxed error type used across async trait boundaries.
+pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
 /// Custom fetch function for injected mode.
 pub type FetchFn = Arc<
-    dyn Fn(FetchRequest) -> Pin<Box<dyn Future<Output = Result<FetchResponse, Box<dyn std::error::Error + Send + Sync>>> + Send>>
+    dyn Fn(FetchRequest) -> Pin<Box<dyn Future<Output = Result<FetchResponse, BoxError>> + Send>>
         + Send
         + Sync,
 >;
 
 /// WebSocket interface for injected mode.
 pub trait InjectedWebSocket: Send + Sync {
-    fn send(&self, data: String) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send + '_>>;
-    fn receive(&self) -> Pin<Box<dyn Future<Output = Result<String, Box<dyn std::error::Error + Send + Sync>>> + Send + '_>>;
-    fn close(&self) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send + '_>>;
+    fn send(&self, data: String) -> Pin<Box<dyn Future<Output = Result<(), BoxError>> + Send + '_>>;
+    fn receive(&self) -> Pin<Box<dyn Future<Output = Result<String, BoxError>> + Send + '_>>;
+    fn close(&self) -> Pin<Box<dyn Future<Output = Result<(), BoxError>> + Send + '_>>;
 }
 
 /// WebSocket factory for injected mode.
 pub type WebSocketFactory = Arc<
-    dyn Fn(String) -> Pin<Box<dyn Future<Output = Result<Box<dyn InjectedWebSocket>, Box<dyn std::error::Error + Send + Sync>>> + Send>>
+    dyn Fn(String) -> Pin<Box<dyn Future<Output = Result<Box<dyn InjectedWebSocket>, BoxError>> + Send>>
         + Send
         + Sync,
 >;


### PR DESCRIPTION
## Summary
- Resolve all 22 clippy warnings: box large enum variants, add type aliases, modernize idioms
- Fix README incorrectly claiming tokio-tungstenite supports proxy env vars

## Test plan
- [ ] `cargo clippy --all-targets --all-features` — 0 warnings
- [ ] `cargo test` — all 19 unit tests + 1 doc test pass
- [ ] `cargo run --example test_proxy` — connects via proxy, HTTP through mitmproxy

Closes #7
Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)