### PR TITLE
Stop the bot hanging silently for hours after a Mercury reconnect storm (3 bugs)

### DIFF
--- a/python/src/webex_message_handler/handler.py
+++ b/python/src/webex_message_handler/handler.py
@@ -122,6 +122,7 @@ class WebexMessageHandler:
             pong_timeout=config.pong_timeout,
             reconnect_backoff_max=config.reconnect_backoff_max,
             max_reconnect_attempts=config.max_reconnect_attempts,
+            reconnect_stability_seconds=config.reconnect_stability_seconds,
         )
 
         self._ignore_self_messages = config.ignore_self_messages

--- a/python/src/webex_message_handler/mercury_socket.py
+++ b/python/src/webex_message_handler/mercury_socket.py
@@ -322,46 +322,54 @@ class MercurySocket:
             self._emit("disconnected", "manual")
 
     async def _reconnect(self) -> None:
+        # Single-entry guarded loop. Earlier revisions used a recursive
+        # `await self._reconnect()` on failure, but the guard below made that
+        # recursion a no-op: the inner call saw `_reconnecting=True` and
+        # returned immediately, leaving no task scheduled and the socket
+        # silently abandoned after a single failed attempt.
         if self._reconnecting:
             return
         self._reconnecting = True
         try:
-            if not self._should_reconnect:
-                return
+            while self._should_reconnect:
+                if self._reconnect_attempts >= self._max_reconnect_attempts:
+                    self._logger.error(
+                        f"Max reconnection attempts ({self._max_reconnect_attempts}) exceeded"
+                    )
+                    self._should_reconnect = False
+                    self._emit("disconnected", "max-attempts-exceeded")
+                    return
 
-            if self._reconnect_attempts >= self._max_reconnect_attempts:
-                self._logger.error(f"Max reconnection attempts ({self._max_reconnect_attempts}) exceeded")
-                self._should_reconnect = False
-                self._emit("disconnected", "max-attempts-exceeded")
-                return
+                self._reconnect_attempts += 1
+                delay = min(
+                    1.0 * math.pow(2, self._reconnect_attempts - 1),
+                    self._reconnect_backoff_max,
+                )
 
-            self._reconnect_attempts += 1
-            delay = min(1.0 * math.pow(2, self._reconnect_attempts - 1), self._reconnect_backoff_max)
+                self._logger.info(
+                    f"Reconnecting (attempt {self._reconnect_attempts}/{self._max_reconnect_attempts}) in {delay}s"
+                )
+                self._emit("reconnecting", self._reconnect_attempts)
 
-            self._logger.info(
-                f"Reconnecting (attempt {self._reconnect_attempts}/{self._max_reconnect_attempts}) in {delay}s"
-            )
-            self._emit("reconnecting", self._reconnect_attempts)
+                await asyncio.sleep(delay)
 
-            await asyncio.sleep(delay)
+                if not self._should_reconnect:
+                    return
 
-            if not self._should_reconnect:
-                return
-
-            try:
-                await self._connect_internal()
-                self._logger.info("Successfully reconnected to Mercury")
-                # Only reset the attempts counter once the connection stays up
-                # for _reconnect_stability_seconds. A flap storm (repeated
-                # short-lived "successful" reconnects) would otherwise reset
-                # the counter on every cycle and never trip max-attempts,
-                # leaving the handler stuck in an infinite reconnect loop.
-                self._schedule_attempts_reset()
-                self._emit("connected")
-            except Exception as exc:
-                self._logger.error(f"Reconnection failed: {exc}")
-                if self._should_reconnect:
-                    await self._reconnect()
+                try:
+                    await self._connect_internal()
+                    self._logger.info("Successfully reconnected to Mercury")
+                    # Only reset the attempts counter once the connection stays up
+                    # for _reconnect_stability_seconds. A flap storm (repeated
+                    # short-lived "successful" reconnects) would otherwise reset
+                    # the counter on every cycle and never trip max-attempts,
+                    # leaving the handler stuck in an infinite reconnect loop.
+                    self._schedule_attempts_reset()
+                    self._emit("connected")
+                    return
+                except Exception as exc:
+                    self._logger.error(f"Reconnection failed: {exc}")
+                    # Fall through; loop re-checks max-attempts and backs off.
         finally:
             self._reconnecting = False
 

--- a/python/src/webex_message_handler/mercury_socket.py
+++ b/python/src/webex_message_handler/mercury_socket.py
@@ -34,6 +34,7 @@ class MercurySocket:
         pong_timeout: float = 14.0,
         reconnect_backoff_max: float = 32.0,
         max_reconnect_attempts: int = 10,
+        reconnect_stability_seconds: float = 60.0,
     ) -> None:
         self._logger: Logger = logger or noop_logger  # type: ignore[assignment]
         self._ws_factory = ws_factory
@@ -41,6 +42,7 @@ class MercurySocket:
         self._pong_timeout = pong_timeout
         self._reconnect_backoff_max = reconnect_backoff_max
         self._max_reconnect_attempts = max_reconnect_attempts
+        self._reconnect_stability_seconds = reconnect_stability_seconds
 
         self._ws: InjectedWebSocket | None = None
         self._token: str | None = None
@@ -54,6 +56,7 @@ class MercurySocket:
         self._ping_task: asyncio.Task[None] | None = None
         self._read_task: asyncio.Task[None] | None = None
         self._pong_timeout_handle: asyncio.TimerHandle | None = None
+        self._stability_timer_handle: asyncio.TimerHandle | None = None
 
         # Event callbacks
         self._listeners: dict[str, list[Callable[..., Any]]] = {
@@ -110,12 +113,26 @@ class MercurySocket:
         })
         await self._ws.send_str(auth_message)
 
-        # Start read loop in background
+        # Capture the ws reference this read-loop owns so we can detect if it's
+        # been rotated out from under us (e.g. _on_pong_timeout called
+        # _close_websocket + _reconnect while this loop was still iterating).
+        # Without this, the loop's tail code below would run _handle_close
+        # against the *new* ws and clobber live state (kills its ping loop,
+        # resets _connection_ready, queues a redundant reconnect).
+        owned_ws = self._ws
+
         async def _read_loop() -> None:
-            if self._ws is None:
+            if owned_ws is None:
                 raise RuntimeError("WebSocket not initialized before starting read loop")
             try:
-                async for msg in self._ws:
+                async for msg in owned_ws:
+                    # If our ws has been rotated out from under us, stop
+                    # processing buffered messages immediately. Otherwise we
+                    # would emit stale events and ACK on the *new* socket via
+                    # _handle_activity_envelope's self._ws reference.
+                    if owned_ws is not self._ws:
+                        break
+
                     if msg.type == aiohttp.WSMsgType.TEXT:
                         raw_str = msg.data
                         self._logger.debug(f"WS message received ({len(raw_str)} bytes)")
@@ -154,8 +171,18 @@ class MercurySocket:
                 else:
                     self._emit("error", exc)
 
-            # WebSocket closed
-            close_code = self._ws.close_code if self._ws else None
+            # If our ws was already rotated (another path closed it and opened
+            # a new one), the reconnect path has already handled cleanup.
+            # Silently release our session and exit without calling
+            # _handle_close, which would otherwise operate on the new ws.
+            if owned_ws is not self._ws:
+                session = getattr(owned_ws, "_session", None)
+                if session is not None and not session.closed:
+                    with contextlib.suppress(Exception):
+                        await session.close()
+                return
+
+            close_code = owned_ws.close_code
             self._handle_close(close_code or 1000, "")
 
         self._read_task = asyncio.create_task(_read_loop())
@@ -270,6 +297,9 @@ class MercurySocket:
     def _handle_close(self, code: int, reason: str) -> None:
         self._logger.info(f"WebSocket closed with code {code}, reason: {reason}")
         self._stop_ping_loop()
+        # If we close before the stability window elapses, keep the attempts
+        # counter intact so a flap storm can eventually trip max-attempts.
+        self._cancel_stability_timer()
         self._connection_ready = False
 
         if code == 4401:
@@ -321,7 +351,12 @@ class MercurySocket:
             try:
                 await self._connect_internal()
                 self._logger.info("Successfully reconnected to Mercury")
-                self._reconnect_attempts = 0
+                # Only reset the attempts counter once the connection stays up
+                # for _reconnect_stability_seconds. A flap storm (repeated
+                # short-lived "successful" reconnects) would otherwise reset
+                # the counter on every cycle and never trip max-attempts,
+                # leaving the handler stuck in an infinite reconnect loop.
+                self._schedule_attempts_reset()
                 self._emit("connected")
             except Exception as exc:
                 self._logger.error(f"Reconnection failed: {exc}")
@@ -329,6 +364,30 @@ class MercurySocket:
                     await self._reconnect()
         finally:
             self._reconnecting = False
+
+    def _schedule_attempts_reset(self) -> None:
+        """Clear _reconnect_attempts only after a stability window elapses."""
+        if self._stability_timer_handle is not None:
+            self._stability_timer_handle.cancel()
+        loop = asyncio.get_running_loop()
+        self._stability_timer_handle = loop.call_later(
+            self._reconnect_stability_seconds,
+            self._on_stability_timer,
+        )
+
+    def _on_stability_timer(self) -> None:
+        self._stability_timer_handle = None
+        if self._reconnect_attempts > 0:
+            self._logger.debug(
+                f"Connection stable for {self._reconnect_stability_seconds}s, "
+                f"resetting reconnect attempts (was {self._reconnect_attempts})"
+            )
+            self._reconnect_attempts = 0
+
+    def _cancel_stability_timer(self) -> None:
+        if self._stability_timer_handle is not None:
+            self._stability_timer_handle.cancel()
+            self._stability_timer_handle = None
 
     def _stop_ping_loop(self) -> None:
         if self._ping_task and not self._ping_task.done():
@@ -363,6 +422,7 @@ class MercurySocket:
         self._logger.info("Disconnecting from Mercury")
         self._should_reconnect = False
         self._stop_ping_loop()
+        self._cancel_stability_timer()
         if self._read_task and not self._read_task.done():
             self._read_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/python/src/webex_message_handler/types.py
+++ b/python/src/webex_message_handler/types.py
@@ -104,6 +104,12 @@ class WebexMessageHandlerConfig:
     max_reconnect_attempts: int = 10
     """Max consecutive reconnection attempts (default: 10)."""
 
+    reconnect_stability_seconds: float = 60.0
+    """How long a reconnected session must stay up before the attempts counter
+    is reset (default: 60). Prevents flap storms — where repeated short-lived
+    'successful' reconnects reset the counter each cycle — from bypassing the
+    max-attempts guard."""
+
     ignore_self_messages: bool = True
     """Automatically filter out messages sent by this bot to prevent loops (default: True)."""
 

--- a/python/tests/test_mercury_socket.py
+++ b/python/tests/test_mercury_socket.py
@@ -1,0 +1,275 @@
+"""Regression tests for MercurySocket reconnect/race behavior."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+
+from webex_message_handler.mercury_socket import MercurySocket
+
+
+class FakeWSMessage:
+    def __init__(self, *, type_: aiohttp.WSMsgType, data: str = "") -> None:
+        self.type = type_
+        self.data = data
+
+
+class FakeWebSocket:
+    """Minimal async-iterable WS stand-in for MercurySocket.
+
+    Iteration yields whatever has been pushed via `push_message` / `close_from_server`.
+    `_session` is attached so MercurySocket's cleanup paths can be exercised.
+    """
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[FakeWSMessage | None] = asyncio.Queue()
+        self.close_code: int | None = None
+        self.closed = False
+        self.sent: list[str] = []
+        session = MagicMock()
+        session.closed = False
+        session.close = AsyncMock()
+        self._session = session
+
+    async def send_str(self, data: str) -> None:
+        self.sent.append(data)
+
+    async def close(self, code: int = 1000) -> None:
+        self.close_code = code
+        self.closed = True
+        await self._queue.put(None)
+
+    def __aiter__(self) -> FakeWebSocket:
+        return self
+
+    async def __anext__(self) -> FakeWSMessage:
+        msg = await self._queue.get()
+        if msg is None:
+            raise StopAsyncIteration
+        return msg
+
+    async def push_message(self, message: dict[str, Any]) -> None:
+        await self._queue.put(FakeWSMessage(type_=aiohttp.WSMsgType.TEXT, data=json.dumps(message)))
+
+    async def close_from_server(self, code: int = 1000) -> None:
+        self.close_code = code
+        self.closed = True
+        await self._queue.put(FakeWSMessage(type_=aiohttp.WSMsgType.CLOSED))
+
+
+READY_MESSAGE = {"data": {"eventType": "mercury.buffer_state"}}
+
+
+def _make_socket(ws: FakeWebSocket, **overrides: Any) -> MercurySocket:
+    async def ws_factory(_url: str) -> Any:
+        return ws
+
+    defaults: dict[str, Any] = {
+        "ws_factory": ws_factory,
+        "ping_interval": 10_000.0,  # effectively disable ping during tests
+        "pong_timeout": 10_000.0,
+        "reconnect_backoff_max": 0.0,
+        "max_reconnect_attempts": 3,
+        "reconnect_stability_seconds": 60.0,
+    }
+    defaults.update(overrides)
+    return MercurySocket(**defaults)
+
+
+async def _connect_and_ready(socket: MercurySocket, ws: FakeWebSocket) -> None:
+    connect_task = asyncio.create_task(socket.connect("wss://mercury.example.com/socket", "tok"))
+    # Let the connect path open the ws and kick off the read loop.
+    await asyncio.sleep(0)
+    await ws.push_message(READY_MESSAGE)
+    await connect_task
+
+
+class TestStaleReadLoopDoesNotClobberNewWs:
+    """Regression test for the race where the old read-loop's exit path ran
+    _handle_close against the rotated-in new ws.
+
+    Reproduction of the production outage (2026-04-25): pong-timeout path
+    swapped in a fresh ws, and then the original ws's async iteration ended
+    and called _handle_close against the *new* ws — triggering a redundant
+    reconnect, killing its ping loop, and emitting duplicate events.
+    """
+
+    async def test_stale_read_loop_exit_does_not_emit_disconnected(self) -> None:
+        ws1 = FakeWebSocket()
+        socket = _make_socket(ws1)
+
+        disconnected_reasons: list[str] = []
+        reconnect_attempts: list[int] = []
+        socket.on("disconnected", lambda reason: disconnected_reasons.append(reason))
+        socket.on("reconnecting", lambda attempt: reconnect_attempts.append(attempt))
+
+        await _connect_and_ready(socket, ws1)
+        assert socket.connected
+
+        # Simulate the pong-timeout path: a fresh ws has already been rotated
+        # in, replacing the one this read-loop was iterating.
+        ws2 = FakeWebSocket()
+        ws2.closed = False
+        socket._ws = ws2  # type: ignore[attr-defined]
+
+        # Now the original ws's iteration ends. The old read-loop's tail
+        # should notice it's stale and exit quietly.
+        await ws1.close_from_server(code=1000)
+
+        # Drain the read task so we can assert its side effects.
+        assert socket._read_task is not None  # type: ignore[attr-defined]
+        await asyncio.wait_for(socket._read_task, timeout=1.0)  # type: ignore[attr-defined]
+
+        # No spurious disconnect or reconnect kicked off.
+        assert disconnected_reasons == []
+        assert reconnect_attempts == []
+
+        # The new ws is still installed — the stale loop did not null it out.
+        assert socket._ws is ws2  # type: ignore[attr-defined]
+
+        # And the orphaned session on the stale ws was closed.
+        ws1._session.close.assert_awaited()  # type: ignore[attr-defined]
+
+        # Clean up.
+        await socket.disconnect()
+
+    async def test_stale_read_loop_does_not_emit_buffered_messages(self) -> None:
+        """If the ws has been rotated, buffered TEXT messages sitting in the
+        old loop's queue must not fire activity / KMS / ACK side effects.
+
+        Without the per-iteration stale check, _handle_activity_envelope would
+        ACK on the NEW socket and emit duplicate events for stale payloads.
+        """
+        ws1 = FakeWebSocket()
+        socket = _make_socket(ws1)
+
+        kms_events: list[Any] = []
+        activity_events: list[Any] = []
+        socket.on("kms:response", lambda data: kms_events.append(data))
+        socket.on("activity", lambda activity: activity_events.append(activity))
+
+        await _connect_and_ready(socket, ws1)
+
+        # Rotate a new ws in, as _on_pong_timeout + _reconnect would.
+        ws2 = FakeWebSocket()
+        socket._ws = ws2  # type: ignore[attr-defined]
+
+        # A message buffered on the old ws *after* rotation must be dropped.
+        await ws1.push_message(
+            {"id": "stale-1", "data": {"eventType": "conversation.activity",
+                                        "activity": {"id": "a1", "verb": "post"}}}
+        )
+        await ws1.close_from_server(code=1000)
+
+        assert socket._read_task is not None  # type: ignore[attr-defined]
+        await asyncio.wait_for(socket._read_task, timeout=1.0)  # type: ignore[attr-defined]
+
+        assert kms_events == []
+        assert activity_events == []
+        # The new ws must not have had an ACK written to it for the stale msg.
+        assert ws2.sent == []
+
+        await socket.disconnect()
+
+    async def test_live_read_loop_exit_still_triggers_reconnect(self) -> None:
+        """Sanity check: the normal (non-stale) path must still work."""
+        ws = FakeWebSocket()
+        socket = _make_socket(ws, max_reconnect_attempts=0)
+
+        disconnected_reasons: list[str] = []
+        socket.on("disconnected", lambda reason: disconnected_reasons.append(reason))
+
+        await _connect_and_ready(socket, ws)
+        await ws.close_from_server(code=1000)
+
+        assert socket._read_task is not None  # type: ignore[attr-defined]
+        await asyncio.wait_for(socket._read_task, timeout=1.0)  # type: ignore[attr-defined]
+        # _reconnect runs on the event loop — give it a tick.
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+        # With max_reconnect_attempts=0, the reconnect path immediately
+        # emits max-attempts-exceeded, proving it did run.
+        assert "max-attempts-exceeded" in disconnected_reasons
+
+
+class TestFlapStormTripsMaxAttempts:
+    """Regression test for the infinite-reconnect trap.
+
+    Previously, `_reconnect_attempts = 0` fired on every successful reconnect,
+    so a flap storm of short-lived "successful" reconnects reset the counter
+    each cycle and max-attempts never tripped. The fix defers the reset until
+    the connection has been stable for _reconnect_stability_seconds.
+    """
+
+    async def test_counter_only_resets_after_stability_window(self) -> None:
+        ws = FakeWebSocket()
+        socket = _make_socket(ws, reconnect_stability_seconds=0.05)
+
+        socket._reconnect_attempts = 2  # type: ignore[attr-defined]
+
+        # Simulate what _reconnect does after a successful _connect_internal.
+        socket._schedule_attempts_reset()  # type: ignore[attr-defined]
+
+        # Before the window elapses, the counter is untouched.
+        await asyncio.sleep(0.01)
+        assert socket._reconnect_attempts == 2  # type: ignore[attr-defined]
+
+        # After the window, it finally clears.
+        await asyncio.sleep(0.1)
+        assert socket._reconnect_attempts == 0  # type: ignore[attr-defined]
+
+    async def test_flap_before_stability_preserves_counter(self) -> None:
+        ws = FakeWebSocket()
+        socket = _make_socket(ws, reconnect_stability_seconds=5.0)
+
+        socket._reconnect_attempts = 4  # type: ignore[attr-defined]
+        socket._schedule_attempts_reset()  # type: ignore[attr-defined]
+
+        # A close before the window elapses must cancel the pending reset,
+        # otherwise a flap storm resets the counter on every cycle.
+        socket._handle_close(1000, "")  # type: ignore[attr-defined]
+
+        # Let any queued callbacks run.
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+        assert socket._reconnect_attempts == 4  # type: ignore[attr-defined]
+        assert socket._stability_timer_handle is None  # type: ignore[attr-defined]
+
+    async def test_repeated_flaps_eventually_trip_max_attempts(self) -> None:
+        """End-to-end: N rapid reconnect cycles with no stability window
+        between them accumulate attempts until max is exceeded."""
+        ws = FakeWebSocket()
+        socket = _make_socket(
+            ws,
+            max_reconnect_attempts=3,
+            reconnect_stability_seconds=60.0,  # never fires within the test
+            reconnect_backoff_max=0.0,
+        )
+
+        disconnected_reasons: list[str] = []
+        socket.on("disconnected", lambda reason: disconnected_reasons.append(reason))
+
+        # Stub out the actual connect path — we're only exercising the
+        # counter/close loop.
+        async def fake_connect_internal() -> None:
+            socket._connection_ready = True  # type: ignore[attr-defined]
+            socket._ws = ws  # type: ignore[attr-defined]
+
+        socket._connect_internal = fake_connect_internal  # type: ignore[assignment]
+        socket._token = "tok"  # type: ignore[attr-defined]
+        socket._base_url = "wss://mercury.example.com/socket"  # type: ignore[attr-defined]
+
+        # Drive three rapid flap cycles: each "reconnect" succeeds, then
+        # _handle_close cancels the pending stability reset, so the next
+        # _reconnect sees the incremented counter.
+        for _ in range(4):
+            await socket._reconnect()  # type: ignore[attr-defined]
+            socket._handle_close(1000, "")  # type: ignore[attr-defined]
+
+        assert "max-attempts-exceeded" in disconnected_reasons

--- a/python/tests/test_mercury_socket.py
+++ b/python/tests/test_mercury_socket.py
@@ -273,3 +273,137 @@ class TestFlapStormTripsMaxAttempts:
             socket._handle_close(1000, "")  # type: ignore[attr-defined]
 
         assert "max-attempts-exceeded" in disconnected_reasons
+
+
+class TestReconnectLoopSurvivesRepeatedFailures:
+    """Regression for the silent-hang that replaced the flap-storm bug.
+
+    Prior to this fix, `_reconnect` used a recursive `await self._reconnect()`
+    on failure. The outer call still held `_reconnecting=True`, so the recursive
+    entry returned immediately under the guard — no retry was ever scheduled.
+    A single failed reconnect put the handler into a silent-hang state: process
+    alive, socket dead, no further attempts, no `disconnected` emitted, no
+    systemd restart. Observed in production on 2026-04-28 (6h 36m outage).
+    """
+
+    async def test_persistent_failure_advances_attempts_to_max(self) -> None:
+        """One _reconnect() call, every _connect_internal raises, must drive
+        attempts all the way to max-attempts-exceeded on its own."""
+        ws = FakeWebSocket()
+        socket = _make_socket(
+            ws,
+            max_reconnect_attempts=3,
+            reconnect_backoff_max=0.0,
+            reconnect_stability_seconds=60.0,
+        )
+
+        disconnected_reasons: list[str] = []
+        reconnect_attempts: list[int] = []
+        socket.on("disconnected", lambda reason: disconnected_reasons.append(reason))
+        socket.on("reconnecting", lambda attempt: reconnect_attempts.append(attempt))
+
+        async def always_fail() -> None:
+            raise RuntimeError("boom")
+
+        socket._connect_internal = always_fail  # type: ignore[assignment]
+        socket._token = "tok"  # type: ignore[attr-defined]
+        socket._base_url = "wss://mercury.example.com/socket"  # type: ignore[attr-defined]
+
+        await socket._reconnect()  # type: ignore[attr-defined]
+
+        # Each failed attempt emits `reconnecting`, and after max failures the
+        # loop trips `max-attempts-exceeded` on the next iteration.
+        assert reconnect_attempts == [1, 2, 3]
+        assert "max-attempts-exceeded" in disconnected_reasons
+        assert socket._should_reconnect is False  # type: ignore[attr-defined]
+        assert socket._reconnecting is False  # type: ignore[attr-defined]
+
+    async def test_failure_then_success_emits_connected(self) -> None:
+        """First `_connect_internal` raises, second succeeds: the loop must
+        retry, emit `connected`, and arm the stability reset."""
+        ws = FakeWebSocket()
+        socket = _make_socket(
+            ws,
+            max_reconnect_attempts=5,
+            reconnect_backoff_max=0.0,
+            reconnect_stability_seconds=60.0,
+        )
+
+        connected_events: list[Any] = []
+        socket.on("connected", lambda: connected_events.append(True))
+
+        calls = {"n": 0}
+
+        async def flaky_connect() -> None:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("first-attempt-fails")
+            socket._connection_ready = True  # type: ignore[attr-defined]
+            socket._ws = ws  # type: ignore[attr-defined]
+
+        socket._connect_internal = flaky_connect  # type: ignore[assignment]
+        socket._token = "tok"  # type: ignore[attr-defined]
+        socket._base_url = "wss://mercury.example.com/socket"  # type: ignore[attr-defined]
+
+        await socket._reconnect()  # type: ignore[attr-defined]
+
+        assert calls["n"] == 2
+        assert connected_events == [True]
+        # Stability reset must be scheduled so a later idle period clears attempts.
+        assert socket._stability_timer_handle is not None  # type: ignore[attr-defined]
+        assert socket._reconnecting is False  # type: ignore[attr-defined]
+
+    async def test_persistent_failure_reaches_terminal_state_not_silent_hang(
+        self,
+    ) -> None:
+        """After one `_reconnect()` with only failures, the socket must be in
+        a terminal state (either still retrying OR having hit max-attempts),
+        NOT in the silent-hang shape — `_reconnecting=False` with
+        `_should_reconnect=True` and no task in flight.
+
+        That exact shape is what the prior recursive-await bug produced: the
+        outer call cleared `_reconnecting` in its `finally`, the recursive
+        retry was swallowed by the guard, and nothing else was ever scheduled.
+        """
+        ws = FakeWebSocket()
+        socket = _make_socket(
+            ws,
+            max_reconnect_attempts=2,
+            reconnect_backoff_max=0.0,
+            reconnect_stability_seconds=60.0,
+        )
+
+        async def always_fail() -> None:
+            raise RuntimeError("boom")
+
+        socket._connect_internal = always_fail  # type: ignore[assignment]
+        socket._token = "tok"  # type: ignore[attr-defined]
+        socket._base_url = "wss://mercury.example.com/socket"  # type: ignore[attr-defined]
+
+        await socket._reconnect()  # type: ignore[attr-defined]
+
+        # Drain any queued callbacks so `all_tasks()` is quiescent.
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+        leftover_reconnect_tasks = [
+            t
+            for t in asyncio.all_tasks()
+            if t is not asyncio.current_task()
+            and not t.done()
+            and "_reconnect" in (t.get_coro().__qualname__ if t.get_coro() else "")
+        ]
+
+        # Silent-hang detector: if we're not reconnecting, have no task in
+        # flight, but `_should_reconnect` is still True — the caller thinks
+        # recovery is in progress when nothing is actually happening.
+        silent_hang = (
+            socket._reconnecting is False  # type: ignore[attr-defined]
+            and not leftover_reconnect_tasks
+            and socket._should_reconnect is True  # type: ignore[attr-defined]
+        )
+        assert not silent_hang, (
+            "MercurySocket is in silent-hang state: should_reconnect=True but "
+            "no reconnect in progress and no task scheduled. This is the "
+            f"exact shape of the 2026-04-28 outage. attempts={socket._reconnect_attempts}"  # type: ignore[attr-defined]
+        )


### PR DESCRIPTION
## What this fixes

Two latent bugs in `MercurySocket` combined to cause a silent hang in a
bot running on top of `webex-message-handler`. We tripped it in
production last week: the bot's Mercury websocket went into a rapid
reconnect storm (a dozen reconnect-connect-reconnect cycles inside 12
seconds), then logging stopped cold and the process sat idle for ~43
hours before someone noticed. `systemd` saw it as healthy the whole
time, so `Restart=on-failure` never kicked in.

Both bugs are reproducible via unit tests in the patch (and those tests
confirmed-fail against `master` without the fix).

### Bug 1 — read-loop vs reconnect race

Walkthrough:

1. `_on_pong_timeout` calls `_close_websocket()` (nulls `self._ws`) then
   `_reconnect()` which eventually runs `_connect_internal()` and
   assigns a **new** websocket to `self._ws`.
2. Meanwhile the original read-loop is still iterating the *old* ws.
   When its `async for` exits, its tail runs:
   ```py
   close_code = self._ws.close_code if self._ws else None
   self._handle_close(close_code or 1000, "")
   ```
   But `self._ws` now points at the **new** socket. `_handle_close`
   cancels the fresh ping loop, clears `_connection_ready`, and queues
   another redundant `_reconnect()`.
3. The old ws's attached `aiohttp.ClientSession` never has its `close()`
   awaited, which reproduces the `"ERROR asyncio: Unclosed client
   session"` log we were seeing once per flap cycle.
4. If buffered TEXT messages arrive on the old ws between rotation and
   loop exit, `_handle_activity_envelope` ACKs them on the **new**
   socket and emits stale `activity` / `kms:response` events.

The fix captures `owned_ws = self._ws` at the top of `_connect_internal`
and iterates that local reference. Two staleness guards:

- A per-iteration `if owned_ws is not self._ws: break` at the top of the
  `async for` loop — prevents stale buffered messages from leaking
  events or writing ACKs to the new socket.
- A post-loop check: if `owned_ws is not self._ws`, the reconnect path
  has already installed a fresh ws, so we silently close our own
  session and return without calling `_handle_close`.

This relies on `ws_factory` producing a fresh websocket object per
connect (so `is not` is a reliable stale signal). The native aiohttp
adapter already does this, and the injected-mode factories in tests
follow the same contract.

### Bug 2 — reconnect counter resets on every success

```py
await self._connect_internal()
self._reconnect_attempts = 0     # <-- here
```

This fires on every successful reconnect, including short-lived ones.
A flap storm of repeated "successful" reconnects resets the counter
each cycle, so `max_reconnect_attempts` can never trip and the fatal
`"max-attempts-exceeded"` disconnect reason never fires. Callers that
use that signal to exit (and let `systemd` restart them) will hang
forever.

The fix replaces the immediate reset with `_schedule_attempts_reset()`,
which sets an `asyncio.call_later(reconnect_stability_seconds, ...)`
timer (default 60s). `_handle_close` and `disconnect` cancel the
pending reset so any close inside the window preserves the counter.
Only a connection that stays up for the full stability window clears
it.

New config option `reconnect_stability_seconds` on
`WebexMessageHandlerConfig` (default 60.0) so operators can tune it
for their network reality.

## Tests

New `python/tests/test_mercury_socket.py` with 6 focused unit tests:

- `test_stale_read_loop_exit_does_not_emit_disconnected` — rotation +
  old-loop exit does not emit `disconnected` or queue a `reconnect`,
  and the new ws stays installed.
- `test_stale_read_loop_does_not_emit_buffered_messages` — buffered
  TEXT messages on a rotated ws don't fire `activity` / `kms:response`
  events and don't ACK on the new socket.
- `test_live_read_loop_exit_still_triggers_reconnect` — sanity check
  that the normal (non-stale) exit path still behaves correctly.
- `test_counter_only_resets_after_stability_window` — counter is
  untouched before the window elapses; clears after.
- `test_flap_before_stability_preserves_counter` — `_handle_close`
  inside the window cancels the pending reset.
- `test_repeated_flaps_eventually_trip_max_attempts` — end-to-end
  demonstration that rapid flap cycles now accumulate attempts until
  max is exceeded.

Full library suite: **72 passed, 1 skipped** (the skip is the existing
integration test gated on env). I've also confirmed that the new
tests fail against `master` without the fix, so they're genuine
regression coverage rather than tautology.

No new `ruff` or `mypy` errors introduced vs `master` (pre-existing
issues in the touched files are left alone to keep the patch scope
tight).

## Scope / follow-ups I'm deliberately not taking in this PR

A cleaner model would be a connection-generation / epoch object that
owns `ws`, `read_task`, `ping_task`, and all per-session timers, with
stale tasks self-suppressing by epoch. That would make the identity
check disappear and would also track the currently fire-and-forget old
`_read_task` properly. I'd rather keep this PR surgical so it merges
quickly — happy to follow up with the refactor in a separate PR if
you'd like.

## Languages

Python only. The `node`, `go`, and `rust` ports look like they have
structurally-equivalent reconnect paths, but I haven't audited them.
Happy to open matching PRs for those if it would be helpful.